### PR TITLE
fix scrollbars in sidebar

### DIFF
--- a/src/app/components/Sidebar/sidebar.css
+++ b/src/app/components/Sidebar/sidebar.css
@@ -20,7 +20,7 @@
   .sidebar {
     height: 100%;
     padding: 8rem 20px 3rem;
-    overflow-y: scroll;
+    overflow-y: auto;
   }
 
   @media screen and (min-width: 769px) {
@@ -31,7 +31,7 @@
       position: sticky;
       top: 10px;
       max-height: 100vh;
-      overflow: scroll;
+      overflow: auto;
     }
 
     .sidebar {


### PR DESCRIPTION
### What's changing?

All that's changing is the `overflow-y` in `.sidebar` and `overflow` in `.sidebar sticky`. They were set to `scroll`, which means that scrollbars are meant to be always visible. I changed them to `auto`, which means that scrollbars will only appear when the content is overflowing the bounds.

This doesn't happen in just windows, it's present in linux as well. The only reason it doesn't show up on macOS, is because macOS has auto hiding scrollbar gutters. A lot of web developers make this mistake because they only test on mac. It's a shame that Apple made that decision tbh, because it means that pages can look perfect on mac and a mess on other OS' (in this case, the sidebar had two layers of scrollbars when it was set to sticky).

## Checklist

closes #61  
