### PR TITLE
fix nav bar logo flex issue

### DIFF
--- a/src/app/components/App/app.css
+++ b/src/app/components/App/app.css
@@ -263,8 +263,11 @@ p > code {
 }
 
 :global .navbar-item img {
-  max-height: 3rem;
   height: 100%;
+}
+
+:global .navbar-item {
+  padding: 0.5rem 20px;
 }
 
 :global .headerLink {

--- a/src/app/components/Header/header.css
+++ b/src/app/components/Header/header.css
@@ -7,6 +7,8 @@
 }
 
 .container {
+  max-width: 100%;
+
   :global .navbar-brand {
     min-height: 100%;
   }
@@ -14,18 +16,17 @@
   @media screen and (min-width: 1024px) {
     display: flex;
     justify-content: space-between;
-    width: 100%;
+    padding: 0 1rem;
   }
 
   @media screen and (min-width: 1800px) {
-    width: 80%;
+    max-width: 80%;
     margin: auto;
   }
 }
 
 .title {
   font-size: 20px;
-  padding: 0;
   padding-right: 50px;
 }
 
@@ -33,8 +34,8 @@
   padding: 0;
 }
 
-.titleText:only-child {
-  padding-left: 1rem;
+.logo {
+  margin-right: 1rem;
 }
 
 :global .navbar {

--- a/src/app/components/Header/index.js
+++ b/src/app/components/Header/index.js
@@ -104,11 +104,11 @@ class Header extends Component {
     );
     return (
       <nav
-        className={makeClass('navbar', styles.nav)}
+        className={makeClass('main-nav navbar', styles.nav)}
         role="navigation"
         aria-label="main navigation"
       >
-        <div className={styles.container}>
+        <div className={makeClass('container', styles.container)}>
           <div className="navbar-brand">
             <Link
               to={path.join(
@@ -119,20 +119,11 @@ class Header extends Component {
               onClick={this.closeMenu}
             >
               {this.props.logo && (
-                <img
-                  src={this.props.logo}
-                  alt="logo"
-                  className={makeClass(styles.logo, 'navbar-item')}
-                />
+                <img src={this.props.logo} alt="logo" className={styles.logo} />
               )}
-              <span
-                className={makeClass(
-                  'is-hidden-mobile navbar-item',
-                  styles.titleText
-                )}
-              >
+              <h1 className={makeClass('is-hidden-mobile', styles.titleText)}>
                 {this.props.title}
-              </span>
+              </h1>
             </Link>
 
             <a


### PR DESCRIPTION
### What's changing?

- Fixed logo deforming disproportionately (closes #65)
- Added some missing bulma nav bar classes on the elements (like `container`. This helped size the logo correctly)
- Removed the global `max-height` of the logo (redundant rule, since bulma already sets the proper height)
- Changed the header text to be an `<h1/>`. There's no reason to use a span, actual header elements help with accessibility and SEO.

### What else might be impacted?

I don't have access to macOS currently, so I need you @hipstersmoothie to make sure the logo is proportionate and stays proportionate in Safari.

The issue I was running into, was occurring whenever the window height was shrunk smaller than the height of the sidebar. For some reason, it was pushing the header bar up a slight bit and deforming the logo. It's fixed now on all the browsers I've tested (Chrome, Firefox, and Epiphany) on Linux.

If you have any questions about anything I changed, just drop questions on the code review.

:v: