### PR TITLE
Support the string version of author in pkg.json

### DIFF
--- a/src/__tests__/ignite.test.js
+++ b/src/__tests__/ignite.test.js
@@ -17,7 +17,6 @@ describe('initPlugins', () => {
       plugins: [['pluginName', '../extensions/notRealExtension/', {}]]
     });
   });
-
   test('should call init function if present', async () => {
     const result = await initPlugins({
       plugins: [['pluginName', 'src/extensions/testExtension/', { foo: 'bar' }]]
@@ -43,10 +42,30 @@ describe('initBlogPosts', () => {
   });
 });
 
-test('getAuthor', () => {
-  expect(getAuthor()).toEqual({
-    email: 'lisowski54@gmail.com',
-    name: 'Andrew Lisowski'
+describe('getAuthor', () => {
+  test('works with obj way', () => {
+    expect(
+      getAuthor({
+        author: {
+          email: 'lisowski54@gmail.com',
+          name: 'Andrew Lisowski'
+        }
+      })
+    ).toEqual({
+      email: 'lisowski54@gmail.com',
+      name: 'Andrew Lisowski'
+    });
+  });
+
+  test('works with string way', () => {
+    expect(
+      getAuthor({
+        author: 'Adam Dierkens <adam@dierkens.com>'
+      })
+    ).toEqual({
+      name: 'Adam Dierkens',
+      email: 'adam@dierkens.com'
+    });
   });
 });
 

--- a/src/ignite.js
+++ b/src/ignite.js
@@ -102,9 +102,23 @@ export async function initBlogPosts(options) {
   return blogPosts.sort((a, b) => a.birth > b.birth);
 }
 
-export function getAuthor() {
-  const rootJson = JSON.parse(fs.readFileSync(`${root()}/package.json`));
-  const author = rootJson ? rootJson.author : {};
+export function getAuthor(pkgJson) {
+  const rootJson =
+    pkgJson || JSON.parse(fs.readFileSync(`${root()}/package.json`));
+  let author = rootJson ? rootJson.author : {};
+
+  if (typeof author === 'string') {
+    // Stolen from https://stackoverflow.com/a/14011481
+    const regexParseMatch = author.match(
+      /(?:"?([^"]*)"?\s)?(?:<?(.+@[^>]+)>?)/
+    );
+    if (regexParseMatch) {
+      author = {
+        name: regexParseMatch[1],
+        email: regexParseMatch[2]
+      };
+    }
+  }
 
   return author;
 }


### PR DESCRIPTION
### What's changing?
Supporting the string version of `author` in a `package.json` when parsing out `name` and `email`

Tried playing with `jest.mock` to mock the `fs` call, but couldn't get it to work without messing up some other tests, so I opted to just be able to supply the `package.json` config directly or read it from disk.

### What else might be impacted?
🤷‍♀️ 

## Checklist

- [ ] Documentation
- [x] New Tests
- [ ] Added myself to contributors table
- [ ] Added SemVer label
- [ ] Ready to be merged
