### PR TITLE
adding a new logo to the project for the OS Site

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@
 
 <div align="center">
   <a href="https://intuit.github.io/Ignite/">
-    <img width="200" height="200"
-      src="https://s3.amazonaws.com/pix.iemoji.com/images/emoji/apple/ios-11/256/fire.png">
+    <img width="250" height="250"
+      src="./os-project-logo.svg">
   </a>
   <h1>
     <a href="https://intuit.github.io/Ignite/">

--- a/os-project-logo.svg
+++ b/os-project-logo.svg
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 22.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 46.2 46.2" style="enable-background:new 0 0 46.2 46.2;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:#F15B2C;}
+	.st1{fill:#F59222;}
+	.st2{fill:#FAAE42;}
+	.st3{fill:#F6E92D;}
+</style>
+<path class="st0" d="M23.6,41c-9.9,0-13.1-7.5-13.2-14.1c0-13.5,12.4-14.5,16.6-21.8C27.1,17,37.4,16.7,37.5,26.8
+	C37.6,35.2,33.5,41,23.6,41z"/>
+<path class="st1" d="M23.8,40.7c-7.6,0-10.7-6.6-10.7-11.6c0-10.9,10.1-13.8,13.5-13.8c0,9,8.2,6.6,8.2,14.3
+	C34.8,36,31.3,40.7,23.8,40.7z"/>
+<path class="st2" d="M23.8,40.3c-5.4,0-7.4-5.4-7.4-9c0-7.7,7.1-9.1,9.5-9.1c0,6.4,5.8,4.7,5.8,10.2C31.7,37,29.2,40.3,23.8,40.3z"
+	/>
+<path class="st3" d="M24,40c-3.5,0-4.6-3.5-4.6-5.8c0-5,4.4-5.8,5.9-5.8c0,4.1,3.7,3,3.7,6.5C29,37.8,27.4,40,24,40z"/>
+</svg>


### PR DESCRIPTION
### What's changing?
In order to showcase ignite in the new Intuit Open Source site, we need a standard for the naming and location of the project's logo, "os-project-logo.svg" to be located in the root directory and used on the readme file for branding alignment. In addition a new logo was created for ignite. 

### What else might be impacted?

## Checklist

- [ X] Documentation
- [ ] New Tests
- [ ] Added myself to contributors table
- [ ] Added SemVer label
- [ X] Ready to be merged

![image](https://user-images.githubusercontent.com/14279937/48794961-59375d80-ecb0-11e8-9af5-2cede067ab9a.png)
