### PR TITLE
Add `customHead` option

### DIFF
--- a/build-utils/webpack.config.development.js
+++ b/build-utils/webpack.config.development.js
@@ -60,7 +60,8 @@ module.exports = function(options) {
         codeStyle: options.codeStyle,
         bulmaTheme: options.bulmaTheme,
         template: path.resolve(__dirname, '../src/index.html'),
-        filename: './index.html'
+        filename: './index.html',
+        customHead: options.customHead
       })
     ]
   };

--- a/build-utils/webpack.config.production.js
+++ b/build-utils/webpack.config.production.js
@@ -153,6 +153,7 @@ module.exports = function(options) {
         bulmaTheme: options.bulmaTheme,
         template: path.resolve(__dirname, '../src/index.html'),
         filename: './index.html',
+        customHead: options.customHead,
         minify: {
           removeComments: true,
           collapseWhitespace: true,

--- a/docs/pages/Options.md
+++ b/docs/pages/Options.md
@@ -123,6 +123,14 @@ ignite --color 'cadetblue'
 ignite --color '#f44336'
 ```
 
+## Custom Head (--customHead)
+
+Specify a string to inject into the head of the page.
+
+```bash
+ignite --customHead '<style>* { color: red; }</style>'
+```
+
 ---
 
 ## Utility Commands

--- a/src/ignite-cli.js
+++ b/src/ignite-cli.js
@@ -66,6 +66,8 @@ const { argv } = yargs
   .default('b', defaults.bulmaTheme)
   .alias('b', 'bulmaTheme')
 
+  .describe('customHead', 'String to load into the head to the webpage')
+
   .describe(
     'static',
     'build website as a static html app. argument should be base url where your static site is served from Some features may now work. (search)'

--- a/src/index.html
+++ b/src/index.html
@@ -1,58 +1,78 @@
 <!DOCTYPE html>
 <html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="X-UA-Compatible" content="ie=edge" />
 
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta http-equiv="X-UA-Compatible" content="ie=edge">
+    <base href="<%= htmlWebpackPlugin.options.base %>" />
 
-  <base href="<%= htmlWebpackPlugin.options.base %>" />
+    <link
+      rel="stylesheet"
+      href="https://use.fontawesome.com/releases/v5.0.12/css/all.css"
+      integrity="sha384-G0fIWCsCzJIMAVNQPfjH08cyYaUtMwjJwqiRKxxE/rx96Uroj1BtIQ6MLJuheaO9"
+      crossorigin="anonymous"
+    />
+    <link
+      rel="stylesheet"
+      href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/styles/<%= htmlWebpackPlugin.options.codeStyle %>.min.css"
+    />
 
-  <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.0.12/css/all.css" integrity="sha384-G0fIWCsCzJIMAVNQPfjH08cyYaUtMwjJwqiRKxxE/rx96Uroj1BtIQ6MLJuheaO9"
-    crossorigin="anonymous">
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/styles/<%= htmlWebpackPlugin.options.codeStyle %>.min.css">
+    <link
+      rel="stylesheet"
+      href="/node_modules/bulma-checkradio/dist/css/bulma-checkradio.min.css"
+    />
 
+    <link
+      rel="stylesheet"
+      href="https://cdnjs.cloudflare.com/ajax/libs/bulmaswatch/0.6.2/<%= htmlWebpackPlugin.options.bulmaTheme %>/bulmaswatch.min.css"
+    />
 
-  <link rel="stylesheet" href="/node_modules/bulma-checkradio/dist/css/bulma-checkradio.min.css">
+    <title>Ignite</title>
 
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bulmaswatch/0.6.2/<%= htmlWebpackPlugin.options.bulmaTheme %>/bulmaswatch.min.css">
+    <%= htmlWebpackPlugin.options.customHead %>
 
-  <title>Ignite</title>
-
-  <script type="text/javascript">
-    // Single Page Apps for GitHub Pages
-    // https://github.com/rafrex/spa-github-pages
-    // Copyright (c) 2016 Rafael Pedicini, licensed under the MIT License
-    // ----------------------------------------------------------------------
-    // This script checks to see if a redirect is present in the query string
-    // and converts it back into the correct url and adds it to the
-    // browser's history using window.history.replaceState(...),
-    // which won't cause the browser to attempt to load the new url.
-    // When the single page app is loaded further down in this file,
-    // the correct url will be waiting in the browser's history for
-    // the single page app to route accordingly.
-    (function (l) {
-      if (l.search) {
-        var q = {};
-        l.search.slice(1).split('&').forEach(function (v) {
-          var a = v.split('=');
-          q[a[0]] = a.slice(1).join('=').replace(/~and~/g, '&');
-        });
-        if (q.p !== undefined) {
-          window.history.replaceState(null, null,
-            l.pathname.slice(0, -1) + (q.p || '') +
-            (q.q ? ('?' + q.q) : '') +
-            l.hash
-          );
+    <script type="text/javascript">
+      // Single Page Apps for GitHub Pages
+      // https://github.com/rafrex/spa-github-pages
+      // Copyright (c) 2016 Rafael Pedicini, licensed under the MIT License
+      // ----------------------------------------------------------------------
+      // This script checks to see if a redirect is present in the query string
+      // and converts it back into the correct url and adds it to the
+      // browser's history using window.history.replaceState(...),
+      // which won't cause the browser to attempt to load the new url.
+      // When the single page app is loaded further down in this file,
+      // the correct url will be waiting in the browser's history for
+      // the single page app to route accordingly.
+      (function(l) {
+        if (l.search) {
+          var q = {};
+          l.search
+            .slice(1)
+            .split('&')
+            .forEach(function(v) {
+              var a = v.split('=');
+              q[a[0]] = a
+                .slice(1)
+                .join('=')
+                .replace(/~and~/g, '&');
+            });
+          if (q.p !== undefined) {
+            window.history.replaceState(
+              null,
+              null,
+              l.pathname.slice(0, -1) +
+                (q.p || '') +
+                (q.q ? '?' + q.q : '') +
+                l.hash
+            );
+          }
         }
-      }
-    }(window.location))
-  </script>
-</head>
+      })(window.location);
+    </script>
+  </head>
 
-<body>
-  <div id="index" style="height: 100%;">
-  </div>
-</body>
-
+  <body>
+    <div id="index" style="height: 100%;"></div>
+  </body>
 </html>


### PR DESCRIPTION
### What's changing?

A user might want to include CSS in their page. This option allow user to inject a string into head of the application.

### What else might be impacted?

Nothing

## Checklist

- [x] Documentation
- [ ] New Tests
- [x] Added myself to contributors table
- [x] Added SemVer label
- [x] Ready to be merged
