### PR TITLE
use --orphan instead of symbolic-ref

### DIFF
--- a/docs/pages/Publishing.md
+++ b/docs/pages/Publishing.md
@@ -9,13 +9,10 @@ Publishing to GitHub pages is easy.
 To publish your docs first set up a clean `gh-pages` branch.
 
 ```bash
-git symbolic-ref HEAD refs/heads/gh-pages
-rm .git/index
-git clean -fdx
-echo "My GitHub Page" > index.html
-git add .
-git commit -a -m "First pages commit"
-git push origin gh-pages
+git checkout --orphan gh-pages
+git rm -rf . (the gitignored files/folders may still be there but nothing to worry)
+git commit --allow-empty -m "empty commit"
+git push -u origin gh-pages
 ```
 
 ## Setup Git


### PR DESCRIPTION
Creating `gh-pages` using `git checkout --orphan <branch_name>`

### What's changing? Publishing.md

### What else might be impacted? nothing else

## Checklist

- [x] Documentation
- [ ] New Tests
- [ ] Added myself to contributors table
- [ ] Added SemVer label
- [ ] Ready to be merged
