### PR TITLE
Fix empty search results in few searches. Issue: #15

### DIFF
--- a/src/app/components/Search/index.js
+++ b/src/app/components/Search/index.js
@@ -108,14 +108,16 @@ class Search extends Component {
     }
 
     let results = await this.index.search(term);
-    results = results.map(result => {
+    const filteredResults = [];
+    results.forEach(result => {
       const page = this.props.searchIndex.find(file => file.id === result);
       const indexes = indexOfAll(page.body, term);
-
-      return [page.id, getLines(page.body, indexes, term)];
+      if (indexes.length !== 0) {
+        filteredResults.push([page.id, getLines(page.body, indexes, term)]);
+      }
     });
 
-    this.props.setSearchResults(results);
+    this.props.setSearchResults(filteredResults);
   });
 
   keyDown = event => {

--- a/src/app/components/Search/index.js
+++ b/src/app/components/Search/index.js
@@ -107,7 +107,7 @@ class Search extends Component {
       return this.props.setSearchResults([]);
     }
 
-    let results = await this.index.search(term);
+    const results = await this.index.search(term);
     const filteredResults = [];
     results.forEach(result => {
       const page = this.props.searchIndex.find(file => file.id === result);


### PR DESCRIPTION
### What's changing?

Filtering of search results.

This is the fix for the issue: https://github.com/intuit/Ignite/issues/15

`js-worker-search` performs a search by splitting the search string by whitespaces. Here's from their doc:

> Searches are case insensitive by default and split on all whitespace characters.

This means, if there's a string `why use redux?` and user searches for `why is` this is split into two searches `why` & `is` hence the search api returns the search has been found because the search string contains `why`. However, when we try to find indexes using `indexOfAll` we do a full search of the search string which is `why is` but we won't get any results. This PR will fix this by checking the indexes to be a valid, only then adding those to search results.

I have also played with `js-worker-search` API using `tokenizePattern` & index params support but nothing seem to be working as well. FYI. May be we can raise a issue with `js-worker-search`.

### What else might be impacted?

Nothing else.

## Checklist

- [ ] Documentation
- [ ] New Tests
- [ ] Added myself to contributors table
- [ ] Added SemVer label
- [x] Ready to be merged
