### PR TITLE
Flexbox bug fix with brand padding. Issue #68

### DIFF
--- a/src/app/components/Header/header.css
+++ b/src/app/components/Header/header.css
@@ -34,6 +34,14 @@
   padding: 0;
 }
 
+.brandBasis {
+  flex-basis: 120px;
+
+  @media screen and (max-width: 768px) {
+    flex-basis: 60px;
+  }
+}
+
 .logo {
   margin-right: 1rem;
 }

--- a/src/app/components/Header/index.js
+++ b/src/app/components/Header/index.js
@@ -115,7 +115,11 @@ class Header extends Component {
                 process.env.baseURL,
                 hasHomePage ? '/home.html' : '/'
               )}
-              className={makeClass(styles.title, 'navbar-item')}
+              className={makeClass(
+                styles.title,
+                'navbar-item',
+                styles.brandBasis
+              )}
               onClick={this.closeMenu}
             >
               {this.props.logo && (


### PR DESCRIPTION
### What's changing?

Fixing the #68 

**Cause**: There was no initial basis on the brand `nav-item`. because of which flex-box width was changing based on the available space(on resizing the window and only when the hamburger menu is shown as its having `display: block`).

**Fix**: Added Initial basis of 120px for the brand `nav-item` which will make sure it will always starts with this width, and won't affected by the window resize which introduces hamburger menu on the screen.

### What else might be impacted?

## Checklist

- [ ] Documentation
- [ ] New Tests
- [ ] Added myself to contributors table
- [ ] Added SemVer label
- [x] Ready to be merged
