### PR TITLE
Remove uglifyjs-webpack-plugin from dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -127,7 +127,6 @@
     "style-loader": "^0.23.1",
     "throttle-debounce": "2.0.1",
     "transform-markdown-links": "^2.0.0",
-    "uglifyjs-webpack-plugin": "2.0.1",
     "webpack": "^4.27.1",
     "webpack-bundle-analyzer": "3.3.2",
     "webpack-cdn-plugin": "2.3.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2157,7 +2157,7 @@ cacache@^10.0.4:
     unique-filename "^1.1.0"
     y18n "^4.0.0"
 
-cacache@^11.0.2, cacache@^11.2.0:
+cacache@^11.0.2:
   version "11.3.1"
   resolved "https://registry.yarnpkg.com/cacache/-/cacache-11.3.1.tgz#d09d25f6c4aca7a6d305d141ae332613aa1d515f"
   integrity sha512-2PEw4cRRDu+iQvBTTuttQifacYjLPhET+SYO/gEFMy8uhi+jlJREDAjSF5FWSdV/Aw5h18caHA7vMTw2c+wDzA==
@@ -11532,14 +11532,6 @@ uglify-js@3.4.x:
     commander "~2.16.0"
     source-map "~0.6.1"
 
-uglify-js@^3.0.0:
-  version "3.4.9"
-  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.4.9.tgz#af02f180c1207d76432e473ed24a28f4a782bae3"
-  integrity sha512-8CJsbKOtEbnJsTyv6LE6m6ZKniqMiFWmm9sRbopbkGs3gMPPfd3Fh8iIA4Ykv5MgaTbqHr4BaoGLJLZNhsrW1Q==
-  dependencies:
-    commander "~2.17.1"
-    source-map "~0.6.1"
-
 uglify-js@^3.1.4:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.6.0.tgz#704681345c53a8b2079fb6cec294b05ead242ff5"
@@ -11547,20 +11539,6 @@ uglify-js@^3.1.4:
   dependencies:
     commander "~2.20.0"
     source-map "~0.6.1"
-
-uglifyjs-webpack-plugin@2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-2.0.1.tgz#f346af53ed496ce72fef462517d417f62bec3010"
-  integrity sha512-1HhCHkOB6wRCcv7htcz1QRPVbWPEY074RP9vzt/X0LF4xXm9l4YGd0qja7z88abDixQlnVwBjXsTBs+Xsn/eeQ==
-  dependencies:
-    cacache "^11.2.0"
-    find-cache-dir "^2.0.0"
-    schema-utils "^1.0.0"
-    serialize-javascript "^1.4.0"
-    source-map "^0.6.1"
-    uglify-js "^3.0.0"
-    webpack-sources "^1.1.0"
-    worker-farm "^1.5.2"
 
 unbzip2-stream@^1.0.9:
   version "1.2.5"


### PR DESCRIPTION
### What's changing?

I was browsing through and saw #82. It seems like uglifyjs is no longer used so there's no need to have it in the dependencies anymore.

Remove `uglifyjs-webpack-plugin` from dependencies

### What else might be impacted?

There might be something I didn't notice that was using it. I already ran `yarn-check` and `grep` to make sure though.

## Checklist

- [x] Documentation
- [x] New Tests
- [ ] Added myself to contributors table
- [ ] Added SemVer label
- [ ] Ready to be merged
